### PR TITLE
Improve DNS sync service error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Docker-native reverse proxy with DNS auto-sync for IONOS.
 - 🔐 HTTPS via Let's Encrypt
 - 📡 Auto DNS A-record creation via IONOS API
 - 🧠 Detects containers using Docker label: \`traefik.domain\`
+- 🪵 Detailed logging and robust error handling in the DNS sync service
 
 ## SSH Key for GitHub
 
@@ -14,12 +15,13 @@ This script checks for or generates \`~/.ssh/aircstack\` for SSH-based GitHub ac
 
 ## Usage
 
-1. Copy and edit:
+1. Copy and edit environment values:
    \`\`\`
    cp .env.example .env
+# edit .env to set EMAIL, DOMAIN, IONOS_API_KEY and TARGET_IP
    \`\`\`
 
-2. Launch:
+2. Launch the stack:
    \`\`\`
    docker compose up --build -d
    \`\`\`

--- a/dns-sync/dns_sync.py
+++ b/dns-sync/dns_sync.py
@@ -1,22 +1,49 @@
+"""Sync IONOS DNS A records with running Docker containers."""
+
 import os
 import time
+import logging
+
 import docker
 import requests
 
 IONOS_API_KEY = os.getenv("IONOS_API_KEY")
 ROOT_DOMAIN = os.getenv("ROOT_DOMAIN")
 TARGET_IP = os.getenv("TARGET_IP")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+if not all([IONOS_API_KEY, ROOT_DOMAIN, TARGET_IP]):
+    raise RuntimeError("Missing one of IONOS_API_KEY, ROOT_DOMAIN or TARGET_IP environment variables")
+
 HEADERS = {"X-API-Key": IONOS_API_KEY, "Content-Type": "application/json"}
 
-def get_zone_id():
-    r = requests.get("https://api.hosting.ionos.com/dns/v1/zones", headers=HEADERS)
-    zones = r.json()
-    for z in zones:
-        if z["name"] == ROOT_DOMAIN:
-            return z["id"]
-    raise Exception("Zone not found")
+
+def _request(method: str, url: str, **kwargs):
+    """Helper performing HTTP requests with error handling."""
+    resp = requests.request(method, url, headers=HEADERS, **kwargs)
+    try:
+        data = resp.json()
+    except ValueError:
+        resp.raise_for_status()
+        raise RuntimeError(f"Invalid JSON response from {url}")
+
+    if not resp.ok:
+        msg = data.get("message", resp.text)
+        raise RuntimeError(f"API error {resp.status_code}: {msg}")
+
+    return data
+
+def get_zone_id() -> str:
+    """Return the zone id for ``ROOT_DOMAIN``."""
+    zones = _request("GET", "https://api.hosting.ionos.com/dns/v1/zones")
+    for zone in zones:
+        if zone.get("name") == ROOT_DOMAIN:
+            return zone.get("id")
+    raise RuntimeError(f"Zone {ROOT_DOMAIN} not found")
 
 def sync_dns():
+    """Synchronize DNS records with running containers."""
     zone_id = get_zone_id()
     client = docker.from_env()
     containers = client.containers.list()
@@ -29,34 +56,45 @@ def sync_dns():
             subdomains.add(domain)
 
     # Get current DNS records
-    r = requests.get(f"https://api.hosting.ionos.com/dns/v1/zones/{zone_id}", headers=HEADERS)
-    current_records = r.json()["records"]
-    current_subs = {r["name"]: r["id"] for r in current_records if r["type"] == "A" and r["content"] == TARGET_IP}
+    zone_info = _request("GET", f"https://api.hosting.ionos.com/dns/v1/zones/{zone_id}")
+    current_records = zone_info.get("records", [])
+    current_subs = {
+        rec.get("name"): rec.get("id")
+        for rec in current_records
+        if rec.get("type") == "A" and rec.get("content") == TARGET_IP
+    }
 
     # Create missing records
     for sub in subdomains:
         if sub not in current_subs:
-            print(f"Creating A record for {sub}")
+            logging.info("Creating A record for %s", sub)
             payload = [{
                 "name": sub,
                 "type": "A",
                 "content": TARGET_IP,
                 "ttl": 3600,
                 "prio": 0,
-                "disabled": False
+                "disabled": False,
             }]
-            requests.post(f"https://api.hosting.ionos.com/dns/v1/zones/{zone_id}/records", headers=HEADERS, json=payload)
+            _request(
+                "POST",
+                f"https://api.hosting.ionos.com/dns/v1/zones/{zone_id}/records",
+                json=payload,
+            )
 
     # Remove stale records
     for name, rid in current_subs.items():
         if name not in subdomains:
-            print(f"Deleting stale DNS record {name}")
-            requests.delete(f"https://api.hosting.ionos.com/dns/v1/zones/{zone_id}/records/{rid}", headers=HEADERS)
+            logging.info("Deleting stale DNS record %s", name)
+            _request(
+                "DELETE",
+                f"https://api.hosting.ionos.com/dns/v1/zones/{zone_id}/records/{rid}",
+            )
 
 if __name__ == "__main__":
     while True:
         try:
             sync_dns()
-        except Exception as e:
-            print("ERROR:", e)
+        except Exception as exc:  # pragma: no cover - top-level loop
+            logging.exception("Error during sync: %s", exc)
         time.sleep(60)


### PR DESCRIPTION
## Summary
- improve logging and error handling in dns_sync.py
- document new capability and environment setup in README

## Testing
- `python3 -m py_compile dns-sync/dns_sync.py`
- `python3 -m pip install --quiet -r dns-sync/requirements.txt`
- `IONOS_API_KEY=foo ROOT_DOMAIN=airc.ai TARGET_IP=1.2.3.4 timeout 5 python3 dns-sync/dns_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_686c39a65e8483309497ef2af3ddf268