### PR TITLE
Remove unused GitHub SSH configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ A Docker-native reverse proxy with DNS auto-sync for IONOS.
 - 🧠 Detects containers using Docker label: \`traefik.domain\`
 - 🪵 Detailed logging and robust error handling in the DNS sync service
 
-## SSH Key for GitHub
-
-This script checks for or generates \`~/.ssh/aircstack\` for SSH-based GitHub access. Add \`aircstack.pub\` to your GitHub SSH keys.
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,6 @@ services:
     container_name: dns-watcher
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
-      - "$HOME/.ssh:/root/.ssh:ro"
     environment:
       IONOS_API_KEY: "${IONOS_API_KEY}"
       ROOT_DOMAIN: "${DOMAIN}"


### PR DESCRIPTION
## Summary
- drop instructions about generating an SSH key for GitHub
- remove the unnecessary SSH volume mount in `docker-compose.yml`

## Testing
- `python -m py_compile dns-sync/dns_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_686c4d8a7a5c833081fab30e02de148a