### PR TITLE
Improve Portainer extension

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,2 @@
 EMAIL=admin@airc.ai
 DOMAIN=airc.ai
-IONOS_API_KEY=your_ionos_api_key
-TARGET_IP=1.1.1.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 __pycache__/
 letsencrypt/
+config/provider.json

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # AircStack
 
-A Docker-native reverse proxy with DNS auto-sync for IONOS.
+A Docker-native reverse proxy with DNS auto-sync for IONOS (or other providers).
 
 ## Features
 
 - 🔐 HTTPS via Let's Encrypt
-- 📡 Auto DNS A-record creation via IONOS API
+- 📡 Auto DNS A-record creation via provider API (IONOS by default)
 - 🧠 Detects containers using Docker label: \`traefik.domain\`
 - 🪵 Detailed logging and robust error handling in the DNS sync service
 
@@ -15,8 +15,10 @@ A Docker-native reverse proxy with DNS auto-sync for IONOS.
 1. Copy and edit environment values:
    \`\`\`
    cp .env.example .env
-# edit .env to set EMAIL, DOMAIN, IONOS_API_KEY and TARGET_IP
+# edit .env to set EMAIL and DOMAIN
 # optional: SYNC_INTERVAL (seconds between DNS checks)
+   cp config/provider.example.json config/provider.json
+# edit config/provider.json with your DNS provider credentials
    \`\`\`
 
 2. Launch the stack:
@@ -28,6 +30,11 @@ The DNS watcher service is built from `dns-sync/Dockerfile` and will
 periodically ensure A records exist for containers that specify the
 `traefik.domain` label.
 
+DNS provider credentials are read from `config/provider.json`. The control
+panel includes a **DNS Provider Settings** page where you can edit the API key,
+root domain and target IP. Only IONOS is supported currently but the format is
+ready for additional providers.
+
 ### Control panel
 
 The stack now includes a small control panel served at
@@ -36,7 +43,8 @@ containers and inspect the live log from the DNS watcher.
 
 ### Portainer extension
 
-A Portainer extension is available in `portainer-extension/`. Import its
-`metadata.json` in Portainer to install the control panel directly inside the
-Portainer UI. The extension builds the same Flask app and exposes it on port
-5000.
+The stack ships with a Portainer extension for the control panel. It is mounted
+into Portainer automatically so no manual import is required. As soon as the
+stack starts, the "Proxy Control" tab is available in Portainer running the
+same Flask app on port 5000. When exposing a container, leaving the subdomain
+blank will default it to the container name.

--- a/config/provider.example.json
+++ b/config/provider.example.json
@@ -1,0 +1,6 @@
+{
+  "provider": "ionos",
+  "ionos_api_key": "your_ionos_api_key",
+  "root_domain": "example.com",
+  "target_ip": "1.2.3.4"
+}

--- a/control-panel/templates/index.html
+++ b/control-panel/templates/index.html
@@ -15,14 +15,18 @@
 </head>
 <body>
     <h1>Reverse Proxy Control Panel</h1>
+    <p><a href="/settings">DNS Provider Settings</a></p>
+    <p>Toggle public routing for your running containers. If you enable a
+        container without entering a subdomain, its name will be used
+        automatically.</p>
     <form method="post" action="/update">
         <table>
-            <tr><th>Container</th><th>Expose</th><th>Subdomain</th></tr>
+            <tr><th>Container</th><th>Public</th><th>Subdomain</th></tr>
             {% for c in containers %}
             <tr>
                 <td>{{ c.name }}</td>
-                <td><input type="checkbox" name="enable_{{ c.id }}" {% if c.enabled %}checked{% endif %}></td>
-                <td><input type="text" name="sub_{{ c.id }}" placeholder="sub" value="{{ c.subdomain }}"></td>
+                <td><input type="checkbox" data-name="{{ c.name }}" name="enable_{{ c.id }}" {% if c.enabled %}checked{% endif %}></td>
+                <td><input type="text" name="sub_{{ c.id }}" placeholder="e.g. app" value="{{ c.subdomain }}"></td>
             </tr>
             {% endfor %}
         </table>
@@ -37,8 +41,21 @@
             const text = await r.text();
             document.getElementById('log').textContent = text;
         }
+        function autoFill() {
+            document.querySelectorAll('input[name^="enable_"]').forEach(cb => {
+                const id = cb.name.slice(7);
+                const input = document.querySelector(`input[name="sub_${id}"]`);
+                if (cb.checked && input && !input.value) {
+                    input.value = cb.dataset.name;
+                }
+            });
+        }
+        document.querySelectorAll('input[name^="enable_"]').forEach(cb => {
+            cb.addEventListener('change', autoFill);
+        });
         setInterval(fetchLog, 3000);
         fetchLog();
+        autoFill();
     </script>
 </body>
 </html>

--- a/control-panel/templates/settings.html
+++ b/control-panel/templates/settings.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DNS Provider Settings</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        label { display: block; margin-top: 1em; }
+        .btn { padding: 0.5em 1em; margin-top: 1em; }
+    </style>
+</head>
+<body>
+    <h1>DNS Provider</h1>
+    <form method="post">
+        <label>
+            Provider
+            <select name="provider">
+                <option value="ionos" {% if data.provider == 'ionos' %}selected{% endif %}>IONOS</option>
+            </select>
+        </label>
+        <label>
+            API Key
+            <input type="text" name="ionos_api_key" value="{{ data.ionos_api_key }}" placeholder="API key">
+        </label>
+        <label>
+            Root Domain
+            <input type="text" name="root_domain" value="{{ data.root_domain }}" placeholder="example.com">
+        </label>
+        <label>
+            Target IP
+            <input type="text" name="target_ip" value="{{ data.target_ip }}" placeholder="1.2.3.4">
+        </label>
+        <button type="submit" class="btn">Save</button>
+    </form>
+    <p><a href="/">Back</a></p>
+</body>
+</html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,14 @@ services:
     image: portainer/portainer-ce:latest
     container_name: portainer
     command: -H unix:///var/run/docker.sock
+    environment:
+      - EXTENSIONS=reverse-proxy
     ports:
       - "9000:9000"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "portainer_data:/data"
+      - "./portainer-extension:/extensions/reverse-proxy"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.portainer.rule=Host(`portainer.${DOMAIN}`)"
@@ -48,10 +51,7 @@ services:
     container_name: dns-watcher
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
-    environment:
-      IONOS_API_KEY: "${IONOS_API_KEY}"
-      ROOT_DOMAIN: "${DOMAIN}"
-      TARGET_IP: "${TARGET_IP}"
+      - "./config:/config"
     restart: always
 
   control-panel:
@@ -59,6 +59,7 @@ services:
     container_name: control-panel
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
+      - "./config:/config"
     environment:
       DOMAIN: "${DOMAIN}"
     labels:

--- a/portainer-extension/docker-compose.yml
+++ b/portainer-extension/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: portainer_extension_control
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ../config:/config
     environment:
       DOMAIN: "${DOMAIN}"
     ports:

--- a/portainer-extension/index.html
+++ b/portainer-extension/index.html
@@ -15,14 +15,18 @@
 </head>
 <body>
     <h1>Reverse Proxy Control Panel</h1>
+    <p><a href="/settings">DNS Provider Settings</a></p>
+    <p>Toggle public routing for your running containers. If you enable a
+        container without entering a subdomain, its name will be used
+        automatically.</p>
     <form method="post" action="/update">
         <table>
-            <tr><th>Container</th><th>Expose</th><th>Subdomain</th></tr>
+            <tr><th>Container</th><th>Public</th><th>Subdomain</th></tr>
             {% for c in containers %}
             <tr>
                 <td>{{ c.name }}</td>
-                <td><input type="checkbox" name="enable_{{ c.id }}" {% if c.enabled %}checked{% endif %}></td>
-                <td><input type="text" name="sub_{{ c.id }}" placeholder="sub" value="{{ c.subdomain }}"></td>
+                <td><input type="checkbox" data-name="{{ c.name }}" name="enable_{{ c.id }}" {% if c.enabled %}checked{% endif %}></td>
+                <td><input type="text" name="sub_{{ c.id }}" placeholder="e.g. app" value="{{ c.subdomain }}"></td>
             </tr>
             {% endfor %}
         </table>
@@ -37,8 +41,21 @@
             const text = await r.text();
             document.getElementById('log').textContent = text;
         }
+        function autoFill() {
+            document.querySelectorAll('input[name^="enable_"]').forEach(cb => {
+                const id = cb.name.slice(7);
+                const input = document.querySelector(`input[name="sub_${id}"]`);
+                if (cb.checked && input && !input.value) {
+                    input.value = cb.dataset.name;
+                }
+            });
+        }
+        document.querySelectorAll('input[name^="enable_"]').forEach(cb => {
+            cb.addEventListener('change', autoFill);
+        });
         setInterval(fetchLog, 3000);
         fetchLog();
+        autoFill();
     </script>
 </body>
 </html>

--- a/portainer-extension/settings.html
+++ b/portainer-extension/settings.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DNS Provider Settings</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        label { display: block; margin-top: 1em; }
+        .btn { padding: 0.5em 1em; margin-top: 1em; }
+    </style>
+</head>
+<body>
+    <h1>DNS Provider</h1>
+    <form method="post">
+        <label>
+            Provider
+            <select name="provider">
+                <option value="ionos" {% if data.provider == 'ionos' %}selected{% endif %}>IONOS</option>
+            </select>
+        </label>
+        <label>
+            API Key
+            <input type="text" name="ionos_api_key" value="{{ data.ionos_api_key }}" placeholder="API key">
+        </label>
+        <label>
+            Root Domain
+            <input type="text" name="root_domain" value="{{ data.root_domain }}" placeholder="example.com">
+        </label>
+        <label>
+            Target IP
+            <input type="text" name="target_ip" value="{{ data.target_ip }}" placeholder="1.2.3.4">
+        </label>
+        <button type="submit" class="btn">Save</button>
+    </form>
+    <p><a href="/">Back</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- auto-install the Portainer extension by mounting it into the Portainer container
- tweak the extension UI wording
- update README to explain that the extension is installed automatically
- auto-fill subdomain with container name when enabling a container
- add DNS provider settings page and shared config file

## Testing
- `python -m py_compile control-panel/app.py dns-sync/dns_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_686c58eaa44483309e04fb7bb2371a41