### PR TITLE
Add settings page to extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ containers and inspect the live log from the DNS watcher.
 ### Portainer extension
 
 The stack ships with a Portainer extension for the control panel. It is mounted
-into Portainer automatically so no manual import is required. As soon as the
-stack starts, the "Proxy Control" tab is available in Portainer running the
-same Flask app on port 5000. When exposing a container, leaving the subdomain
-blank will default it to the container name.
+into Portainer automatically so no manual import is required. Once the stack
+starts, the **Proxy Control** tab will appear in Portainer using the same Flask
+app on port 5000. The extension also adds a **DNS Provider** item under
+Portainer's **Settings** side menu where you can manage API credentials and the
+target IP. When exposing a container, leaving the subdomain blank will default
+it to the container name.

--- a/portainer-extension/metadata.json
+++ b/portainer-extension/metadata.json
@@ -13,6 +13,12 @@
       "root": "/",
       "src": "index.html",
       "backend": { "tcp": "5000" }
+    },
+    "settings": {
+      "title": "DNS Provider",
+      "root": "/settings",
+      "src": "settings.html",
+      "backend": { "tcp": "5000" }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `settings` view in Portainer extension metadata for side menu
- document location of DNS Provider settings in README

## Testing
- `python -m py_compile control-panel/app.py dns-sync/dns_sync.py`
- `jq . portainer-extension/metadata.json`

------
https://chatgpt.com/codex/tasks/task_e_686c5ebe01a8833090e6ea766591afc3