### PR TITLE
Add interactive start helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ A Docker-native reverse proxy with DNS auto-sync for IONOS (or other providers).
 # edit config/provider.json with your DNS provider credentials
    \`\`\`
 
-2. Launch the stack:
+2. Launch the stack with the interactive script:
    \`\`\`
-   docker compose up --build -d
+   ./start.sh
    \`\`\`
+Choose an option to build or rebuild the containers as needed.
 
 The DNS watcher service is built from `dns-sync/Dockerfile` and will
 periodically ensure A records exist for containers that specify the

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+COMPOSE="docker compose"
+
+if ! command -v docker >/dev/null; then
+    echo "Docker is required but not installed." >&2
+    exit 1
+fi
+
+function start_build() {
+    $COMPOSE up -d --build
+}
+
+function remove_and_rebuild() {
+    $COMPOSE down
+    $COMPOSE up -d --build
+}
+
+function build_only() {
+    $COMPOSE build
+}
+
+function purge_build() {
+    $COMPOSE down -v --rmi all --remove-orphans
+    $COMPOSE up -d --build
+}
+
+function show_menu() {
+    echo "AircStack start script"
+    echo "======================"
+    echo "1) Build and start"
+    echo "2) Remove containers then rebuild"
+    echo "3) Build images only"
+    echo "4) Purge volumes/images then rebuild"
+    echo "5) Quit"
+    echo
+    read -rp "Select an option [1-5]: " choice
+    case "$choice" in
+        1) start_build ;;
+        2) remove_and_rebuild ;;
+        3) build_only ;;
+        4) purge_build ;;
+        5) echo "Exiting." ; exit 0 ;;
+        *) echo "Invalid option" ; exit 1 ;;
+    esac
+}
+
+show_menu


### PR DESCRIPTION
## Summary
- add `start.sh` interactive Docker start script
- document script in README

## Testing
- `shellcheck start.sh`


------
https://chatgpt.com/codex/tasks/task_e_686c6154d6e88330a41a0ea37114f7b9