### PR TITLE
Fix portainer extension not visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,14 @@ app on port 5000. The extension also adds a **DNS Provider** item under
 Portainer's **Settings** side menu where you can manage API credentials and the
 target IP. When exposing a container, leaving the subdomain blank will default
 it to the container name.
+
+**Important:** Starting with Portainer 2.19, the Community Edition no longer
+loads local extensions. This stack pins `portainer/portainer-ce:2.18.4` so the
+Proxy Control extension remains visible. If you need a newer Portainer release,
+consider the Business Edition instead.
+
+If you started Portainer previously without the extension mounted, the
+`portainer_data` volume may cache the old state and hide the extension even
+after updating the stack. Run `./start.sh` and choose the option to purge
+volumes (or manually `docker compose down -v && docker volume rm
+aircstack_portainer_data`) to recreate the volume and load the extension.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "traefik.http.routers.api.tls.certresolver=le"
 
   portainer:
-    image: portainer/portainer-ce:latest
+    image: portainer/portainer-ce:2.18.4
     container_name: portainer
     command: -H unix:///var/run/docker.sock
     environment:


### PR DESCRIPTION
## Summary
- note that Portainer CE 2.19+ can't load local extensions
- pin the stack to portainer/portainer-ce:2.18.4
- warn that the `portainer_data` volume may need purging to load the extension

## Testing
- `python -m py_compile control-panel/app.py dns-sync/dns_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_686c63f4da1083308cbc9f742f85fb80