### PR TITLE
Fix check_extension for images without /bin/sh

### DIFF
--- a/check_extension.sh
+++ b/check_extension.sh
@@ -15,7 +15,7 @@ if ! docker ps -q -f name="^${CONTAINER}$" | grep -q .; then
   exit 1
 fi
 
-if docker exec "$CONTAINER" /bin/sh -c "test -f $EXT_DIR/metadata.json"; then
+if docker exec "$CONTAINER" test -f "$EXT_DIR/metadata.json"; then
   echo "Extension is mounted"
 else
   echo "Extension not found at $EXT_DIR" >&2


### PR DESCRIPTION
## Summary
- avoid specifying `/bin/sh` in `check_extension.sh`

## Testing
- `./check_extension.sh` *(fails: Docker is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ca3699c3c8330a1c1ca77c1b26978